### PR TITLE
Transition Homotopy + Directory management

### DIFF
--- a/examples.mag
+++ b/examples.mag
@@ -30,7 +30,7 @@ end function;
 
 // Generate a smooth quartic
 P<x,y,z,w> := PolynomialRing(Rationals(),4);
-f:=smoothPolynomial(P,4);
+f:=smoothPolynomial(P,4 : sparse:=4);
 
 // Compute a path of deformation, compatible cohomology bases at each step, find Picard-Fuchs equations, determine initial conditions, write to a Sage readable file (current.sage)
 time ph:=PeriodHomotopy([f]);
@@ -194,6 +194,7 @@ x^5 + x*z*w^3 + y^5 + z^4*w
 ];
 
 
+// This example presently does not finish computing within an hour.
 // Curve of high genus
 P<x,y,z>:=PolynomialRing(Rationals(),3);
 u:=20;

--- a/examples.mag
+++ b/examples.mag
@@ -1,8 +1,36 @@
 // load period-suite
-load "suite.mag";
+Attach("suite.mag");
+
+
+function randomHomPoly(ring,deg : coefSize:=10, sparse:=0)
+    mons:=MonomialsOfDegree(ring,deg);
+    if sparse gt 0 then
+        mons:=IndexedSetToSet(MonomialsOfDegree(ring,deg));
+        mons:=SetToSequence(RandomSubset(mons,sparse));
+    end if;
+    repeat
+        p:=&+[Random([-coefSize..coefSize])*mon : mon in mons];
+    until not p eq 0;
+    return p;
+end function;
+
+function smoothPolynomial(ring,deg : coefSize:=10, sparse:=5, verbose:=false)
+    attemptNo:=0;
+    repeat
+        f:=randomHomPoly(ring,deg : sparse:=sparse, coefSize:=coefSize);
+        if verbose then
+            attemptNo+:=1;
+            print "Attempt number:",attemptNo;
+            print "f=",f;
+        end if;
+    until not IsSingular(Scheme(Proj(ring),f));
+    return f;
+end function;
+
 
 // Generate a smooth quartic
-f:=smoothHypersurface(P,4);
+P<x,y,z,w> := PolynomialRing(Rationals(),4);
+f:=smoothPolynomial(P,4);
 
 // Compute a path of deformation, compatible cohomology bases at each step, find Picard-Fuchs equations, determine initial conditions, write to a Sage readable file (current.sage)
 time ph:=PeriodHomotopy([f]);
@@ -167,7 +195,6 @@ x^5 + x*z*w^3 + y^5 + z^4*w
 
 
 // Curve of high genus
-load "suite.mag";
 P<x,y,z>:=PolynomialRing(Rationals(),3);
 u:=20;
 f:=x^(3*u)+y^(3*u)+z^(3*u)+x^u*y^u*z^u;

--- a/integrator.sage
+++ b/integrator.sage
@@ -1,4 +1,4 @@
-pathToSuite="/Users/sertoez/git-projects/suite/";
+pathToSuite="/usr/people/avinash/Gauss-Manin/PeriodSuite/";
 load(pathToSuite+"ivpdir.sage")
 ncpus=100
 

--- a/integrator.sage
+++ b/integrator.sage
@@ -1,5 +1,10 @@
 pathToSuite="/usr/people/avinash/Gauss-Manin/PeriodSuite/";
-load(pathToSuite+"ivpdir.sage")
+
+# Magma source has been changed so that the Temp-directory is sent via the System call.
+# This enables us to specify the load directory from a sage application, as well as prevent
+# a concurrency issue.
+""" Example statement: ivpdir="/usr/people/avinash/Gauss-Manin/PeriodSuite/ode_storage/test/" """
+
 ncpus=100
 
 print("Beginning integration...")

--- a/integrator.sage
+++ b/integrator.sage
@@ -14,6 +14,7 @@ field=ComplexBallField(bit_precision)
 
 @parallel(ncpus=ncpus)
 def integrate_ode(ode_label):
+    print("Old script: Core initiated")
     load(ode_label)
     if loop_position > -1:
         return integrate_ode_with_loop(ode_label)

--- a/make
+++ b/make
@@ -6,6 +6,7 @@ integrator="integrator.sage"
 
 mkdir -p ${pathToSuite}"/""ode_storage/incinerator";
 mkdir -p ${pathToSuite}"/""fermat_data";
+touch ${pathToSuite}"/""ode_storage/incinerator/.PERIODSUITE-this-directory-is-safe-to-rm-fr";
 
 sed -i.backup "1d" $suite
 sed -i.backup "1i\\

--- a/suite.mag
+++ b/suite.mag
@@ -1359,10 +1359,11 @@ intrinsic TransitionHomotopy(path::[RngMPolElt] :
   beginningTime:=Realtime();
   ivpdir:=PeriodSuiteTempDir(:subfolder:=name);
   CheckIfIVPDirectoryExists(name, ivpdir, overwrite);
-  
-  WriteInsideTempFolder("meta.sage","precision="*Sprint(precision):name:=name);
-  WriteInsideTempFolder("meta.sage","d="*Sprint(Degree(path[1])):name:=name);
-  WriteInsideTempFolder("meta.sage","reduce="*Sprint(reduce_initials):name:=name);
+
+  WriteInsideTempFolder("meta.sage","steps="*Sprint(#path-1)          : name:=name);
+  WriteInsideTempFolder("meta.sage","precision="*Sprint(precision)    : name:=name);
+  WriteInsideTempFolder("meta.sage","d="*Sprint(Degree(path[1]))      : name:=name);
+  WriteInsideTempFolder("meta.sage","reduce="*Sprint(reduce_initials) : name:=name);
   
   // either the right number of integrationPaths should be provided, or none at all
   if #integrationPaths eq 0 then integrationPaths:=[[] : i in [1..(#path-1)]]; end if;

--- a/suite.mag
+++ b/suite.mag
@@ -1371,9 +1371,11 @@ function SingularLocusInFamily(f0,f1)
 end function;
 
 intrinsic TransitionHomotopy(path::[RngMPolElt] :
-			      precision:=100, straight:=false, bound_pole_order:=true,
-			      pathfinder:=0, integrationPaths:=[], reduce_initials:=true,name:="",
-			      overwrite:=false,integrate:=true) -> Any
+			     precision:=100, straight:=false,
+			     bound_pole_order:=false,
+			     pathfinder:=0, integrationPaths:=[],
+			     reduce_initials:=true, name:="",
+			     overwrite:=false, integrate:=true) -> Any
 {
     Computes the transition matrices needed to carry periods from paths[1] to paths[#paths].
 }
@@ -1383,7 +1385,6 @@ intrinsic TransitionHomotopy(path::[RngMPolElt] :
   if #path eq 1 then
     error "Transition Homotopy needs start and endpoint as input. Perhaps you meant PeriodHomotopy?";
   end if;
-
 
   beginningTime:=Realtime();
   ivpdir:=PeriodSuiteTempDir(:subfolder:=name);
@@ -1425,8 +1426,10 @@ intrinsic TransitionHomotopy(path::[RngMPolElt] :
       
       ivps:=ConstructIVPs(path[i],path[i+1] :
 			  pathfinder:=pathfinder, family_number:=i,
-			  integrationPath:=integrationPaths[i], pole_order_bound:=0,
-			  reduce_initials:=reduce_initials,precision:=precision,
+			  integrationPath:=integrationPaths[i],
+			  pole_order_bound:=pole_order_bound,
+			  reduce_initials:=reduce_initials,
+			  precision:=precision,
 			  f1_is_smooth:=f1_is_smooth);
       
       Append(~allODEs,ivps`ODEs);

--- a/suite.mag
+++ b/suite.mag
@@ -1,4 +1,4 @@
-pathToSuite:="/Users/sertoez/git-projects/suite/";
+pathToSuite:="/usr/people/avinash/Gauss-Manin/PeriodSuite/";
 
 intrinsic PathToSuite() -> MonStgElt
 { Returns the directory of period-suite. }
@@ -1235,6 +1235,106 @@ intrinsic PeriodHomotopy(path::[RngMPolElt] : precision:=100, straight:=false, b
   if not IsFermat(path[1]) then
     error "The initial polynomial is not of fermat type." ;
   end if;
+
+  beginningTime:=Realtime();
+  ivpdir:=PeriodSuiteTempDir(:subfolder:=name);
+  // if no name has been specified then set overwrite to true and clear ivpdir
+  overwrite:=overwrite or (#name eq 0);
+  // check if ivpdir exists
+  if System("[ -d "*ivpdir*" ]") eq 0 then
+    if overwrite then
+      System("rm -fr "*ivpdir*"*");
+    else
+      error "folder name already exists, change 'name' or set 'overwrite:=true'";
+    end if;
+  else 
+    System("mkdir "*ivpdir);
+  end if;
+
+  WriteInsideTempFolder("meta.sage","precision="*Sprint(precision):name:=name);
+  WriteInsideTempFolder("meta.sage","d="*Sprint(Degree(path[1])):name:=name);
+  WriteInsideTempFolder("meta.sage","fermat_type="*Sprint(Coefficients(path[1])):name:=name);
+  WriteInsideTempFolder("meta.sage","reduce="*Sprint(reduce_initials):name:=name);
+  
+  // either the right number of integrationPaths should be provided, or none at all
+  if #integrationPaths eq 0 then integrationPaths:=[[] : i in [1..(#path-1)]]; end if;
+  assert #integrationPaths eq #path-1; 
+
+
+  target:=path[#path]; 
+  target_is_smooth:=isSmooth(target);
+  P:=Parent(target);
+  n:=Ngens(P)-2;
+  d:=Degree(target); 
+  if d eq 1 then
+    error "Degree of the hypersurface needs to be greater than one.";
+  end if;
+
+  // bounding the pole order of cohomology classes for the target hypersurface accelerates the procedure, while providing complete information on the Hodge decomposition
+  // but we can only bound pole order, if there is non-zero classes outside of H^{n/2,n/2}
+  if Ceiling(n/2)*d-Ngens(P) lt 0 then bound_pole_order:=false; end if;
+  pole_order_bound:=bound_pole_order select Ceiling(n/2) else 0;
+
+  allODEs:=[];
+  tstart:=Realtime();
+  for i in [1..(#path-1)] do
+    print "\n\n************************************\nWe are at family number",i,"out of",#path-1,"\n************************************\n";
+    if i ne (#path-1) then
+      pob:=0; // pole order bound
+      f1_is_smooth:=true;
+    else
+      pob:=pole_order_bound; // in the last step we need only compute some of the periods
+      f1_is_smooth:=target_is_smooth;
+    end if;
+      ivps:=ConstructIVPs(path[i],path[i+1] : pathfinder:=pathfinder, family_number:=i, integrationPath:=integrationPaths[i], pole_order_bound:=pob, reduce_initials:=reduce_initials,precision:=precision, f1_is_smooth:=f1_is_smooth);
+      Append(~allODEs,ivps`ODEs);
+
+      WriteIVPsToFile(ivps : number:=i, max_number:=#path-1, name:=name);
+    // to parallelize one could start integration at this point, or even sooner for each IVP
+  end for;
+
+  print "\n\nIf this is the first time, we will compute a Pham basis for the Fermat hypersurface of degree", d, "and dimension", n;
+  // intmat is not urgent, but phamB is recorded for sage to use
+  phamB,intmat:=WriteToFileHomAndCohOfFermat(n,d); 
+  // define a period bundle
+  bundle:=rec<PeriodBundle | equation:=path[#path],dimension:=n,degree:=d, primitiveIntersectionMatrix:=Matrix(intmat),phamBasis:=phamB,
+  odes:=allODEs,
+  deformation:=path, cohomBasis:=ivps`movingBasis,
+  name:=name
+  >;
+  printf "\nComputation of the differential equations is now complete (%o seconds).\n\n", Realtime()-tstart;
+
+  ////////////////////////////////////////
+  /// Integration happens here ///////////
+  ////////////////////////////////////////
+  if integrate then
+    print "Starting integration.\n\n";
+    bundle:=SolveIVPs(bundle);
+  end if;
+  ////////////////////////////////////////
+  ////////////////////////////////////////
+
+  pathMons:=[#Monomials(p) : p in path];
+  pathMonsChange:=[#Monomials(path[j]-path[j-1]) : j in [2..#path]];
+  print "Used the following path:",path;
+  print "The number of monomials appearing at each step:\n",pathMons;
+  print "The number of monomials changed at each step:\n",pathMonsChange;
+
+  if #name gt 0 then SaveBundle(bundle); end if;
+
+  return bundle, ivpdir;
+end intrinsic;
+
+intrinsic TransistionHomotopy(path::[RngMPolElt] : precision:=100, straight:=false, bound_pole_order:=true, pathfinder:=0, integrationPaths:=[], reduce_initials:=true,name:="",overwrite:=false,integrate:=true) -> Any
+{
+  Computes the periods of the hypersurface appearing as the last entry of "path". First all the periods of intermediate hypersurfaces in order to reach the target hypersurface.
+}
+
+  if #path eq 1 then
+    error "Transition Homotopy needs start and endpoint as input. Perhaps you intended PeriodHomotopy?";
+  end if;
+    return PeriodHomotopy(path[1] : precision:=precision, straight:=straight, bound_pole_order:=bound_pole_order,pathfinder:=pathfinder, reduce_initials:=reduce_initials, name:=name, overwrite:=overwrite,integrate:=integrate); end if;
+
 
   beginningTime:=Realtime();
   ivpdir:=PeriodSuiteTempDir(:subfolder:=name);

--- a/suite.mag
+++ b/suite.mag
@@ -1362,7 +1362,6 @@ intrinsic TransitionHomotopy(path::[RngMPolElt] :
   
   WriteInsideTempFolder("meta.sage","precision="*Sprint(precision):name:=name);
   WriteInsideTempFolder("meta.sage","d="*Sprint(Degree(path[1])):name:=name);
-  WriteInsideTempFolder("meta.sage","fermat_type="*Sprint(Coefficients(path[1])):name:=name);
   WriteInsideTempFolder("meta.sage","reduce="*Sprint(reduce_initials):name:=name);
   
   // either the right number of integrationPaths should be provided, or none at all
@@ -1391,17 +1390,12 @@ intrinsic TransitionHomotopy(path::[RngMPolElt] :
       print "\n\n************************************\nWe are at family number",i,
 	    "out of",#path-1,"\n************************************\n";
 
-      if i ne (#path-1) then
-	  pob:=0; // pole order bound
-	  f1_is_smooth:=true;
-      else
-	  pob:=pole_order_bound; // in the last step we need only compute some of the periods
-	  f1_is_smooth:=target_is_smooth;
-      end if;
-
+      pob:=0; // pole order bound
+      f1_is_smooth:=target_is_smooth;
+      
       ivps:=ConstructIVPs(path[i],path[i+1] :
 			  pathfinder:=pathfinder, family_number:=i,
-			  integrationPath:=integrationPaths[i], pole_order_bound:=pob,
+			  integrationPath:=integrationPaths[i], pole_order_bound:=0,
 			  reduce_initials:=reduce_initials,precision:=precision,
 			  f1_is_smooth:=f1_is_smooth);
       

--- a/suite.mag
+++ b/suite.mag
@@ -1325,22 +1325,10 @@ intrinsic PeriodHomotopy(path::[RngMPolElt] : precision:=100, straight:=false, b
   return bundle, ivpdir;
 end intrinsic;
 
-intrinsic TransistionHomotopy(path::[RngMPolElt] : precision:=100, straight:=false, bound_pole_order:=true, pathfinder:=0, integrationPaths:=[], reduce_initials:=true,name:="",overwrite:=false,integrate:=true) -> Any
-{
-  Computes the periods of the hypersurface appearing as the last entry of "path". First all the periods of intermediate hypersurfaces in order to reach the target hypersurface.
-}
-
-  if #path eq 1 then
-    error "Transition Homotopy needs start and endpoint as input. Perhaps you intended PeriodHomotopy?";
-  end if;
-    return PeriodHomotopy(path[1] : precision:=precision, straight:=straight, bound_pole_order:=bound_pole_order,pathfinder:=pathfinder, reduce_initials:=reduce_initials, name:=name, overwrite:=overwrite,integrate:=integrate); end if;
-
-
-  beginningTime:=Realtime();
-  ivpdir:=PeriodSuiteTempDir(:subfolder:=name);
+procedure CheckIfIVPDirectoryExists(name, ivpdir, overwrite)
   // if no name has been specified then set overwrite to true and clear ivpdir
   overwrite:=overwrite or (#name eq 0);
-  // check if ivpdir exists
+
   if System("[ -d "*ivpdir*" ]") eq 0 then
     if overwrite then
       System("rm -fr "*ivpdir*"*");
@@ -1351,6 +1339,27 @@ intrinsic TransistionHomotopy(path::[RngMPolElt] : precision:=100, straight:=fal
     System("mkdir "*ivpdir);
   end if;
 
+end procedure;
+
+
+intrinsic TransitionHomotopy(path::[RngMPolElt] :
+			      precision:=100, straight:=false, bound_pole_order:=true,
+			      pathfinder:=0, integrationPaths:=[], reduce_initials:=true,name:="",
+			      overwrite:=false,integrate:=true) -> Any
+{
+    Computes the periods of the hypersurface appearing as the last entry of "path".
+    First all the periods of intermediate hypersurfaces in order to reach the target hypersurface.
+}
+
+  if #path eq 1 then
+    error "Transition Homotopy needs start and endpoint as input. Perhaps you meant PeriodHomotopy?";
+  end if;
+
+
+  beginningTime:=Realtime();
+  ivpdir:=PeriodSuiteTempDir(:subfolder:=name);
+  CheckIfIVPDirectoryExists(name, ivpdir, overwrite);
+  
   WriteInsideTempFolder("meta.sage","precision="*Sprint(precision):name:=name);
   WriteInsideTempFolder("meta.sage","d="*Sprint(Degree(path[1])):name:=name);
   WriteInsideTempFolder("meta.sage","fermat_type="*Sprint(Coefficients(path[1])):name:=name);
@@ -1370,7 +1379,8 @@ intrinsic TransistionHomotopy(path::[RngMPolElt] : precision:=100, straight:=fal
     error "Degree of the hypersurface needs to be greater than one.";
   end if;
 
-  // bounding the pole order of cohomology classes for the target hypersurface accelerates the procedure, while providing complete information on the Hodge decomposition
+  // bounding the pole order of cohomology classes for the target hypersurface accelerates
+  // the procedure, while providing complete information on the Hodge decomposition
   // but we can only bound pole order, if there is non-zero classes outside of H^{n/2,n/2}
   if Ceiling(n/2)*d-Ngens(P) lt 0 then bound_pole_order:=false; end if;
   pole_order_bound:=bound_pole_order select Ceiling(n/2) else 0;
@@ -1378,38 +1388,44 @@ intrinsic TransistionHomotopy(path::[RngMPolElt] : precision:=100, straight:=fal
   allODEs:=[];
   tstart:=Realtime();
   for i in [1..(#path-1)] do
-    print "\n\n************************************\nWe are at family number",i,"out of",#path-1,"\n************************************\n";
-    if i ne (#path-1) then
-      pob:=0; // pole order bound
-      f1_is_smooth:=true;
-    else
-      pob:=pole_order_bound; // in the last step we need only compute some of the periods
-      f1_is_smooth:=target_is_smooth;
-    end if;
-      ivps:=ConstructIVPs(path[i],path[i+1] : pathfinder:=pathfinder, family_number:=i, integrationPath:=integrationPaths[i], pole_order_bound:=pob, reduce_initials:=reduce_initials,precision:=precision, f1_is_smooth:=f1_is_smooth);
+      print "\n\n************************************\nWe are at family number",i,
+	    "out of",#path-1,"\n************************************\n";
+
+      if i ne (#path-1) then
+	  pob:=0; // pole order bound
+	  f1_is_smooth:=true;
+      else
+	  pob:=pole_order_bound; // in the last step we need only compute some of the periods
+	  f1_is_smooth:=target_is_smooth;
+      end if;
+
+      ivps:=ConstructIVPs(path[i],path[i+1] :
+			  pathfinder:=pathfinder, family_number:=i,
+			  integrationPath:=integrationPaths[i], pole_order_bound:=pob,
+			  reduce_initials:=reduce_initials,precision:=precision,
+			  f1_is_smooth:=f1_is_smooth);
+      
       Append(~allODEs,ivps`ODEs);
 
       WriteIVPsToFile(ivps : number:=i, max_number:=#path-1, name:=name);
-    // to parallelize one could start integration at this point, or even sooner for each IVP
+      // to parallelize one could start integration at this point, or even sooner for each IVP
   end for;
 
-  print "\n\nIf this is the first time, we will compute a Pham basis for the Fermat hypersurface of degree", d, "and dimension", n;
-  // intmat is not urgent, but phamB is recorded for sage to use
-  phamB,intmat:=WriteToFileHomAndCohOfFermat(n,d); 
   // define a period bundle
-  bundle:=rec<PeriodBundle | equation:=path[#path],dimension:=n,degree:=d, primitiveIntersectionMatrix:=Matrix(intmat),phamBasis:=phamB,
-  odes:=allODEs,
-  deformation:=path, cohomBasis:=ivps`movingBasis,
-  name:=name
-  >;
-  printf "\nComputation of the differential equations is now complete (%o seconds).\n\n", Realtime()-tstart;
+  bundle:=rec<PeriodBundle | equation:=path[#path],dimension:=n,degree:=d,
+			     primitiveIntersectionMatrix:="", phamBasis:="",
+			     odes:=allODEs,
+			     deformation:=path, cohomBasis:=ivps`movingBasis,
+			     name:=name >;
+  printf "\nComputation of the differential equations is now complete (%o seconds).\n\n",
+	 Realtime()-tstart;
 
   ////////////////////////////////////////
   /// Integration happens here ///////////
   ////////////////////////////////////////
   if integrate then
     print "Starting integration.\n\n";
-    bundle:=SolveIVPs(bundle);
+    bundle:=SolveTransitionIVPs(bundle);
   end if;
   ////////////////////////////////////////
   ////////////////////////////////////////
@@ -1470,6 +1486,26 @@ intrinsic SolveIVPs(bundle::Any) -> Any
   return bundle;
 
 end intrinsic;
+
+
+intrinsic SolveTransitionIVPs(bundle::Any) -> Any
+{
+    Takes as input the name of the initial value problems which have been saved in storage directory and integrates them. This version takes the period bundle, which is faster than loading in from file.
+}
+    name:=bundle`name;
+    ivpdir:=PeriodSuiteTempDir(:subfolder:=name);
+    cols := GetColumns();
+    SetColumns(0);
+    print "\n\nStarting SageMath, this may take some time...\n\n";
+    Write(pathToSuite*"ivpdir.sage", "ivpdir=\""*ivpdir*"\";" : Overwrite:=true);
+    SetColumns(cols);
+    System("$(which sage) "*PathToSuite()*"transition-integrator.sage");
+
+
+    return bundle;
+
+end intrinsic;
+
 
 intrinsic LoadBundle(name::MonStgElt : withPeriods:=true) -> Any
 {

--- a/suite.mag
+++ b/suite.mag
@@ -1474,16 +1474,23 @@ intrinsic SolveTransitionIVPs(bundle::Any) -> Any
 {
     Takes as input the name of the initial value problems which have been saved in storage directory and integrates them. This version takes the period bundle, which is faster than loading in from file.
 }
-    name:=bundle`name;
-    ivpdir:=PeriodSuiteTempDir(:subfolder:=name);
-    cols := GetColumns();
-    SetColumns(0);
-    print "\n\nStarting SageMath, this may take some time...\n\n";
-    Write(pathToSuite*"ivpdir.sage", "ivpdir=\""*ivpdir*"\";" : Overwrite:=true);
-    SetColumns(cols);
-    System("$(which sage) "*PathToSuite()*"transition-integrator.sage");
+  name:=bundle`name;
+  ivpdir:=PeriodSuiteTempDir(:subfolder:=name);
 
-    return bundle;
+  /* cols := GetColumns(); */
+  /* SetColumns(0); */
+  /* print "\n\nStarting SageMath, this may take some time...\n\n"; */
+  /* Write(pathToSuite*"ivpdir.sage", "ivpdir=\""*ivpdir*"\";" : Overwrite:=true); */
+  /* SetColumns(cols); */
+
+  print "\n\nStarting SageMath, this may take some time...\n\n";
+
+  // Format command string. Remember that command strings need quotes.
+  cmd_string := Sprintf("ivpdir=\"%o\"; load(\"%o\")", ivpdir,
+			PathToSuite()*"transition-integrator.sage");
+
+  System(Sprintf("$(which sage) -c '%o'", cmd_string));
+  return bundle;
 end intrinsic;
 
 
@@ -1506,12 +1513,16 @@ intrinsic SolveIVPs(bundle::Any) -> Any
 }
   name:=bundle`name;
   ivpdir:=PeriodSuiteTempDir(:subfolder:=name);
-  cols := GetColumns();
-  SetColumns(0);
+  
   print "\n\nStarting SageMath, this may take some time...\n\n";
-  Write(pathToSuite*"ivpdir.sage", "ivpdir=\""*ivpdir*"\";" : Overwrite:=true);
-  SetColumns(cols);
-  System("$(which sage) "*PathToSuite()*"integrator.sage");
+  //cols := GetColumns();
+  // SetColumns(0);
+  // Write(pathToSuite*"ivpdir.sage", "ivpdir=\""*ivpdir*"\";" : Overwrite:=true);
+  //SetColumns(cols);
+
+  // Format command string. Remember that command strings need quotes. 
+  cmd_string := Sprintf("ivpdir=\"%o\"; load(\"%o\")", ivpdir, PathToSuite()*"integrator.sage");
+  System(Sprintf("$(which sage) -c '%o'", cmd_string));
 
   if isSmooth(bundle`equation) then
     bundle`primitivePeriods,bundle`precision:=loadPeriods(ivpdir*"periods");

--- a/suite.mag
+++ b/suite.mag
@@ -1,9 +1,9 @@
+pathToSuite:="/usr/people/avinash/Gauss-Manin/PeriodSuite/";
+
 //************************************************************************************************
 // Global constants.
 //************************************************************************************************
 
-
-pathToSuite:="/usr/people/avinash/Gauss-Manin/PeriodSuite/";
 SAFEOVERWRITECODE := ".PERIODSUITE-this-directory-is-safe-to-rm-fr";
 
 //************************************************************************************************
@@ -32,7 +32,8 @@ end intrinsic;
 
 intrinsic IVPWorkingDir(:subfolder:="") -> MonStgElt
 {
- Returns the directory for temp files of period-suite. 
+Returns either the directory for temp files of period-suite or, if subfolder is specified,
+the directory to the identified subfolder.
 }
   if #subfolder eq 0 then
     return PathToSuite()*"ode_storage/incinerator/";
@@ -77,7 +78,7 @@ procedure CheckIfIVPDirectoryExists(name, ivpdir, overwrite)
   // Unix conditional check to see if directory exists and if it is safe to overwrite.
   if System("[ -d "*ivpdir*" ]") eq 0 then
 
-    error if not System("[ -f "*ivpdir*SAFEOVERWRITECODE*" ]" ),
+    error if System("[ -f "*ivpdir*SAFEOVERWRITECODE*" ]" ) ne 0,
 	     "Safe overwrite file: '"*SAFEOVERWRITECODE*"' does not exist in directory. "*
 	     "If you *really* want `rm -fr *` to run in this directory, create this file "*
 	     "and try again.";

--- a/suite.mag
+++ b/suite.mag
@@ -1,4 +1,15 @@
+//************************************************************************************************
+// Global constants.
+//************************************************************************************************
+
+
 pathToSuite:="/usr/people/avinash/Gauss-Manin/PeriodSuite/";
+SAFEOVERWRITECODE := ".PERIODSUITE-this-directory-is-safe-to-rm-fr"
+
+//************************************************************************************************
+// Directory management and File I/O
+//************************************************************************************************
+
 
 intrinsic PathToSuite() -> MonStgElt
 { Returns the directory of period-suite. }
@@ -57,6 +68,33 @@ intrinsic WriteInsideStorageFolder(filename::MonStgElt, string::MonStgElt : Over
   Write(target,string : Overwrite:=Overwrite);
   SetColumns(cols);
 end intrinsic;
+
+procedure CheckIfIVPDirectoryExists(name, ivpdir, overwrite)
+  // if no name has been specified then set overwrite to true and clear ivpdir
+  overwrite:=overwrite or (#name eq 0);
+
+  // Unix conditional check to see if directory exists and if it is safe to overwrite.
+  if System("[ -d "*ivpdir*" ]") eq 0 then
+
+    error if not System("[ -f "ivpdir*SAFEOVERWRITECODE*" ]" ),
+	     "Safe overwrite file: '"*SAFEOVERWRITECODE*"' does not exist in directory. "*
+	     "If you *really* want `rm -fr *` to run in this directory, create this file "*
+	     "and try again.";
+
+    error if not overwrite, "folder name already exists, change 'name' or set 'overwrite:=true'";
+    System("rm -fr "*ivpdir * "*");
+    System("touch "*ivpdir*SAFEOVERWRITECODE); // Reset the safe overwrite file.
+  else 
+    System("mkdir "*ivpdir);
+    System("touch "*ivpdir*SAFEOVERWRITECODE);
+  end if;
+
+end procedure;
+
+
+//************************************************************************************************
+// Fermat methods
+//************************************************************************************************
 
 intrinsic Fermat(n::RngIntElt,d::RngIntElt : type:=[1 : i in [1..n+2]], P:=PolynomialRing(Rationals(),n+2)) -> RngMPolElt
 { Returns the polynomial of a Fermat hypersurface of dimension n and of degree d}
@@ -1245,18 +1283,7 @@ intrinsic PeriodHomotopy(path::[RngMPolElt] : precision:=100, straight:=false, b
 
   beginningTime:=Realtime();
   ivpdir:=PeriodSuiteTempDir(:subfolder:=name);
-  // if no name has been specified then set overwrite to true and clear ivpdir
-  overwrite:=overwrite or (#name eq 0);
-  // check if ivpdir exists
-  if System("[ -d "*ivpdir*" ]") eq 0 then
-    if overwrite then
-      System("rm -fr "*ivpdir*"*");
-    else
-      error "folder name already exists, change 'name' or set 'overwrite:=true'";
-    end if;
-  else 
-    System("mkdir "*ivpdir);
-  end if;
+  CheckIfIVPDirectoryExists(name, ivpdir, overwrite)
 
   WriteInsideTempFolder("meta.sage","precision="*Sprint(precision):name:=name);
   WriteInsideTempFolder("meta.sage","d="*Sprint(Degree(path[1])):name:=name);
@@ -1332,21 +1359,6 @@ intrinsic PeriodHomotopy(path::[RngMPolElt] : precision:=100, straight:=false, b
   return bundle, ivpdir;
 end intrinsic;
 
-procedure CheckIfIVPDirectoryExists(name, ivpdir, overwrite)
-  // if no name has been specified then set overwrite to true and clear ivpdir
-  overwrite:=overwrite or (#name eq 0);
-
-  if System("[ -d "*ivpdir*" ]") eq 0 then
-    if overwrite then
-      System("rm -fr "*ivpdir*"*");
-    else
-      error "folder name already exists, change 'name' or set 'overwrite:=true'";
-    end if;
-  else 
-    System("mkdir "*ivpdir);
-  end if;
-
-end procedure;
 
 //****************************************
 // TransitionHomotopy Section.
@@ -1551,7 +1563,7 @@ intrinsic LoadBundle(name::MonStgElt : withPeriods:=true) -> Any
   Reads the "bundle" file written under the storage directory with the given name, construct the corresponding PeriodBundle and returns it.
 }
 
-  ivpdir:=PeriodSuiteTempDir(:subfolder:=name);
+  ivpdir:=IVPWorkingDir(:subfolder:=name);
   filename:=ivpdir*"bundle";
   file:=Open(filename,"r");
   bundle:=rec<PeriodBundle | name:=name >;

--- a/suite.mag
+++ b/suite.mag
@@ -1341,14 +1341,15 @@ procedure CheckIfIVPDirectoryExists(name, ivpdir, overwrite)
 
 end procedure;
 
+//****************************************
+// TransitionHomotopy Section.
 
 intrinsic TransitionHomotopy(path::[RngMPolElt] :
 			      precision:=100, straight:=false, bound_pole_order:=true,
 			      pathfinder:=0, integrationPaths:=[], reduce_initials:=true,name:="",
 			      overwrite:=false,integrate:=true) -> Any
 {
-    Computes the periods of the hypersurface appearing as the last entry of "path".
-    First all the periods of intermediate hypersurfaces in order to reach the target hypersurface.
+    Computes the transition matrices needed to carry periods from paths[1] to paths[#paths].
 }
 
   if #path eq 1 then
@@ -1436,6 +1437,44 @@ intrinsic TransitionHomotopy(path::[RngMPolElt] :
   return bundle, ivpdir;
 end intrinsic;
 
+// Input: f0,f1
+// Output: None.
+// Determines a list of polynomials whose roots specify the values of t
+// for which (1-t)*f0 + t*f1 is singular. Usually this is just the list [1].
+//
+// Data is written to a file for sage to read the input.
+// Specifically the voronoi_path function.
+procedure WriteSingularPointsInFamily(f0,f1, filename)
+    P := Parent(f0);
+    R<t> := PolynomialRing(Rationals(), Ngens(P)+1, "elim", 1);
+    inc := hom<P->R|[R.i : i in [2..Ngens(R)]]>;
+    F  := (1-t)*inc(f0)+t*inc(f1);
+    I  := ideal<R|[Derivative(F,i): i in [2..Ngens(R)]]>;
+    J  := ideal<R|[R.i : i in [2..Ngens(R)]]>;
+    IJ := Saturation(I,J);
+    gb := GroebnerBasis(IJ);
+    polys :=[p : p in gb | IsUnivariate(p,t)];
+    return;
+end procedure;
+
+intrinsic SolveTransitionIVPs(bundle::Any) -> Any
+{
+    Takes as input the name of the initial value problems which have been saved in storage directory and integrates them. This version takes the period bundle, which is faster than loading in from file.
+}
+    name:=bundle`name;
+    ivpdir:=PeriodSuiteTempDir(:subfolder:=name);
+    cols := GetColumns();
+    SetColumns(0);
+    print "\n\nStarting SageMath, this may take some time...\n\n";
+    Write(pathToSuite*"ivpdir.sage", "ivpdir=\""*ivpdir*"\";" : Overwrite:=true);
+    SetColumns(cols);
+    System("$(which sage) "*PathToSuite()*"transition-integrator.sage");
+
+    return bundle;
+end intrinsic;
+
+
+//****************************************  End TransitionHomotopy Section.
 
 intrinsic SolveIVPs(name::MonStgElt) -> Any
 {
@@ -1479,25 +1518,6 @@ intrinsic SolveIVPs(bundle::Any) -> Any
   end if;
 
   return bundle;
-
-end intrinsic;
-
-
-intrinsic SolveTransitionIVPs(bundle::Any) -> Any
-{
-    Takes as input the name of the initial value problems which have been saved in storage directory and integrates them. This version takes the period bundle, which is faster than loading in from file.
-}
-    name:=bundle`name;
-    ivpdir:=PeriodSuiteTempDir(:subfolder:=name);
-    cols := GetColumns();
-    SetColumns(0);
-    print "\n\nStarting SageMath, this may take some time...\n\n";
-    Write(pathToSuite*"ivpdir.sage", "ivpdir=\""*ivpdir*"\";" : Overwrite:=true);
-    SetColumns(cols);
-    System("$(which sage) "*PathToSuite()*"transition-integrator.sage");
-
-
-    return bundle;
 
 end intrinsic;
 

--- a/suite.mag
+++ b/suite.mag
@@ -1141,7 +1141,7 @@ intrinsic suffix(number::RngIntElt,  max_number::RngIntElt) -> MonStgElt
   return Sprint(10^digits+number)[2..(digits+1)];
 end intrinsic;
 
-intrinsic WriteIVPsToFile(E::Rec : number:=0, max_number:=0, name:="")
+intrinsic WriteIVPsToFile(E::Rec : number:=0, max_number:=0, name:="", singular_locus:=false)
 {
   Writes the output of ConstructIVPs in a format readable by Sage.
 }
@@ -1158,12 +1158,19 @@ intrinsic WriteIVPsToFile(E::Rec : number:=0, max_number:=0, name:="")
   
   for i in [1..#E`ODEs] do
     ode_filename:="IVP-"*suffix(number,max_number)*"-"*suffix(i,#E`ODEs)*".sage";
-    WriteInsideTempFolder(ode_filename,"ode="*Sprint(E`ODEs[i]) : Overwrite:=true,name:=name);
-    WriteInsideTempFolder(ode_filename,"init="*Sprint(E`inits[i]):name:=name);
+      
+    WriteInsideTempFolder(ode_filename, "ode="  *Sprint(E`ODEs[i])  : Overwrite:=true,name:=name);
+    WriteInsideTempFolder(ode_filename, "init=" *Sprint(E`inits[i]) : name:=name);
+
     //WriteInsideTempFolder(ode_filename,"precision="*Sprint(E`precision):name:=name);
-    WriteInsideTempFolder(ode_filename,"path="*Sprint(E`integrationPath):name:=name);
-    WriteInsideTempFolder(ode_filename,"label=("*Sprint(number)*","*Sprint(i)*")":name:=name);
-    WriteInsideTempFolder(ode_filename,"loop_position="*Sprint(E`loop_position):name:=name);
+
+    WriteInsideTempFolder(ode_filename, "path="   *Sprint(E`integrationPath)        : name:=name);
+    WriteInsideTempFolder(ode_filename, "label=(" *Sprint(number)*","*Sprint(i)*")" : name:=name);
+    WriteInsideTempFolder(ode_filename, "loop_position=" *Sprint(E`loop_position)   : name:=name);
+
+    if Type(singular_locus) ne BoolElt then
+      WriteInsideTempFolder(ode_filename,"singular_locus="*Sprint(singular_locus) : name:=name);
+    end if;
   end for;
 
   // not required
@@ -1344,6 +1351,25 @@ end procedure;
 //****************************************
 // TransitionHomotopy Section.
 
+// Input: f0,f1
+// Output: A list of polynomials whose roots specify the values of t
+// for which (1-t)*f0 + t*f1 is singular. Usually this is just the list [1].
+//
+function SingularLocusInFamily(f0,f1)
+    P := Parent(f0);
+    R<t> := PolynomialRing(Rationals(), Ngens(P)+1, "elim", 1);
+    inc := hom<P->R|[R.i : i in [2..Ngens(R)]]>;
+    
+    F  := (1-t)*inc(f0)+t*inc(f1);
+    I  := ideal<R|[Derivative(F,i): i in [2..Ngens(R)]]>;
+    J  := ideal<R|[R.i : i in [2..Ngens(R)]]>;
+
+    IJ := Saturation(I,J);
+    gb := GroebnerBasis(IJ);
+    polys :=[p : p in gb | IsUnivariate(p,t)];
+    return polys;
+end function;
+
 intrinsic TransitionHomotopy(path::[RngMPolElt] :
 			      precision:=100, straight:=false, bound_pole_order:=true,
 			      pathfinder:=0, integrationPaths:=[], reduce_initials:=true,name:="",
@@ -1351,6 +1377,8 @@ intrinsic TransitionHomotopy(path::[RngMPolElt] :
 {
     Computes the transition matrices needed to carry periods from paths[1] to paths[#paths].
 }
+  // NOTE: integration paths here means the list of quartics to get from start to finish,
+  //       instead of the real contor inside a P1 used to compute the transition matrices.
 
   if #path eq 1 then
     error "Transition Homotopy needs start and endpoint as input. Perhaps you meant PeriodHomotopy?";
@@ -1403,8 +1431,10 @@ intrinsic TransitionHomotopy(path::[RngMPolElt] :
       
       Append(~allODEs,ivps`ODEs);
 
-      WriteIVPsToFile(ivps : number:=i, max_number:=#path-1, name:=name);
-      // to parallelize one could start integration at this point, or even sooner for each IVP
+      slocus := SingularLocusInFamily(path[i],path[i+1]);
+      WriteIVPsToFile(ivps : number:=i, max_number:=#path-1,
+			     name:=name, singular_locus := slocus);
+
   end for;
 
   // define a period bundle
@@ -1436,26 +1466,6 @@ intrinsic TransitionHomotopy(path::[RngMPolElt] :
 
   return bundle, ivpdir;
 end intrinsic;
-
-// Input: f0,f1
-// Output: None.
-// Determines a list of polynomials whose roots specify the values of t
-// for which (1-t)*f0 + t*f1 is singular. Usually this is just the list [1].
-//
-// Data is written to a file for sage to read the input.
-// Specifically the voronoi_path function.
-procedure WriteSingularPointsInFamily(f0,f1, filename)
-    P := Parent(f0);
-    R<t> := PolynomialRing(Rationals(), Ngens(P)+1, "elim", 1);
-    inc := hom<P->R|[R.i : i in [2..Ngens(R)]]>;
-    F  := (1-t)*inc(f0)+t*inc(f1);
-    I  := ideal<R|[Derivative(F,i): i in [2..Ngens(R)]]>;
-    J  := ideal<R|[R.i : i in [2..Ngens(R)]]>;
-    IJ := Saturation(I,J);
-    gb := GroebnerBasis(IJ);
-    polys :=[p : p in gb | IsUnivariate(p,t)];
-    return;
-end procedure;
 
 intrinsic SolveTransitionIVPs(bundle::Any) -> Any
 {

--- a/suite.mag
+++ b/suite.mag
@@ -4,7 +4,7 @@
 
 
 pathToSuite:="/usr/people/avinash/Gauss-Manin/PeriodSuite/";
-SAFEOVERWRITECODE := ".PERIODSUITE-this-directory-is-safe-to-rm-fr"
+SAFEOVERWRITECODE := ".PERIODSUITE-this-directory-is-safe-to-rm-fr";
 
 //************************************************************************************************
 // Directory management and File I/O
@@ -30,7 +30,7 @@ intrinsic PeriodSuiteStorageDir(:subfolder:="") -> MonStgElt
   end if;
 end intrinsic;
 
-intrinsic PeriodSuiteTempDir(:subfolder:="") -> MonStgElt
+intrinsic IVPWorkingDir(:subfolder:="") -> MonStgElt
 {
  Returns the directory for temp files of period-suite. 
 }
@@ -46,7 +46,7 @@ intrinsic WriteInsideTempFolder(filename::MonStgElt, string::MonStgElt : Overwri
   Writes the string to filename inside the appropriate folder within period-suite. Takes care of line breaking issues.
 }
   cols := GetColumns();
-  ivpdir:=PeriodSuiteTempDir(:subfolder:=name);
+  ivpdir:=IVPWorkingDir(:subfolder:=name);
   target:=ivpdir*filename;
   SetColumns(0);
   if (#name gt 0) and createFolder then
@@ -70,13 +70,14 @@ intrinsic WriteInsideStorageFolder(filename::MonStgElt, string::MonStgElt : Over
 end intrinsic;
 
 procedure CheckIfIVPDirectoryExists(name, ivpdir, overwrite)
+    
   // if no name has been specified then set overwrite to true and clear ivpdir
   overwrite:=overwrite or (#name eq 0);
 
   // Unix conditional check to see if directory exists and if it is safe to overwrite.
   if System("[ -d "*ivpdir*" ]") eq 0 then
 
-    error if not System("[ -f "ivpdir*SAFEOVERWRITECODE*" ]" ),
+    error if not System("[ -f "*ivpdir*SAFEOVERWRITECODE*" ]" ),
 	     "Safe overwrite file: '"*SAFEOVERWRITECODE*"' does not exist in directory. "*
 	     "If you *really* want `rm -fr *` to run in this directory, create this file "*
 	     "and try again.";
@@ -93,7 +94,7 @@ end procedure;
 
 
 //************************************************************************************************
-// Fermat methods
+// Fermat polynomial construction methods
 //************************************************************************************************
 
 intrinsic Fermat(n::RngIntElt,d::RngIntElt : type:=[1 : i in [1..n+2]], P:=PolynomialRing(Rationals(),n+2)) -> RngMPolElt
@@ -105,6 +106,12 @@ intrinsic Fermat(P::RngMPol,d::RngIntElt : type:=[1 : i in [1..Ngens(P)]]) -> Rn
 { Returns the Fermat polynomial degree d in the polynomial ring P}
   return &+[ type[i]*P.i^d : i in [1..Ngens(P)]];
 end intrinsic;
+
+
+
+//************************************************************************************************
+// Picard-Fuchs related functions.
+//************************************************************************************************
 
 // input: 
 // L a nested list of polynomials
@@ -357,6 +364,11 @@ intrinsic PicardFuchs(forms::SeqEnum,f::RngMPolElt : max_order:=0, family_number
   return PFeqns;
 
 end intrinsic;
+
+//************************************************************************************************
+// Cohomology basis functions.
+//************************************************************************************************
+
 
 // pole_order_bound if non-zero constructs a cohomology basis which, using Griffiths residues, has pole order at most "pole_order_bound"
 intrinsic CompatibleCohomologyBasis(f0::RngMPolElt,f1::RngMPolElt : pole_order_bound:=0) -> SeqEnum
@@ -633,6 +645,11 @@ intrinsic LocalBasis(ode::RngUPolElt) -> SeqEnum
   return Reverse(exps); 
 end intrinsic;
 
+
+//************************************************************************************************
+// Functions to compute derivatives of forms.
+//************************************************************************************************
+
 intrinsic DifferentiateForm(numerator::RngMPolElt,f0::RngMPolElt,f1::RngMPolElt) -> RngMPolElt
 {
  Differentiates the form numerator*Omega/((1-t)*f0 + t*f1)^l, and outputs the new numerator.
@@ -682,6 +699,15 @@ intrinsic Analytics(ODEs::SeqEnum) -> SeqEnum
 }
   return [Analytics(odes) : odes in ODEs];
 end intrinsic;
+
+
+ 
+//************************************************************************************************
+//
+// Functions for solving Initial Value Problems (IVPs).
+//
+//************************************************************************************************
+
 
 // initial value problems
 IVPs := recformat<ODEs,movingBasis,inits,changeBasis,t,analytics,integrationPath,pointsToAvoid,loop_position>;
@@ -793,6 +819,14 @@ intrinsic ConstructAndWriteIVPs(f0::RngMPolElt, f1::RngMPolElt : pole_order_boun
   return B;
 
 end intrinsic;
+
+
+
+//************************************************************************************************
+//
+// Stuff....
+//
+//************************************************************************************************
 
 
 intrinsic LatticeOfRelations(periodMatrix,precision::RngIntElt : offset:=20, Delta:=0.9999, Eta:=0.5001, DeepInsertions:=false, Proof:=false, ForceRelation:=false) -> RngIntElt, SeqEnum
@@ -1282,8 +1316,8 @@ intrinsic PeriodHomotopy(path::[RngMPolElt] : precision:=100, straight:=false, b
   end if;
 
   beginningTime:=Realtime();
-  ivpdir:=PeriodSuiteTempDir(:subfolder:=name);
-  CheckIfIVPDirectoryExists(name, ivpdir, overwrite)
+  ivpdir:=IVPWorkingDir(:subfolder:=name);
+  CheckIfIVPDirectoryExists(name, ivpdir, overwrite);
 
   WriteInsideTempFolder("meta.sage","precision="*Sprint(precision):name:=name);
   WriteInsideTempFolder("meta.sage","d="*Sprint(Degree(path[1])):name:=name);
@@ -1399,7 +1433,7 @@ intrinsic TransitionHomotopy(path::[RngMPolElt] :
   end if;
 
   beginningTime:=Realtime();
-  ivpdir:=PeriodSuiteTempDir(:subfolder:=name);
+  ivpdir:=IVPWorkingDir(:subfolder:=name);
   CheckIfIVPDirectoryExists(name, ivpdir, overwrite);
 
   WriteInsideTempFolder("meta.sage","steps="*Sprint(#path-1)          : name:=name);
@@ -1487,7 +1521,7 @@ intrinsic SolveTransitionIVPs(bundle::Any) -> Any
     Takes as input the name of the initial value problems which have been saved in storage directory and integrates them. This version takes the period bundle, which is faster than loading in from file.
 }
   name:=bundle`name;
-  ivpdir:=PeriodSuiteTempDir(:subfolder:=name);
+  ivpdir:=IVPWorkingDir(:subfolder:=name);
 
   /* cols := GetColumns(); */
   /* SetColumns(0); */
@@ -1524,7 +1558,7 @@ intrinsic SolveIVPs(bundle::Any) -> Any
   Takes as input the name of the initial value problems which have been saved in storage directory and integrates them. This version takes the period bundle, which is faster than loading in from file.
 }
   name:=bundle`name;
-  ivpdir:=PeriodSuiteTempDir(:subfolder:=name);
+  ivpdir:=IVPWorkingDir(:subfolder:=name);
   
   print "\n\nStarting SageMath, this may take some time...\n\n";
   //cols := GetColumns();

--- a/transition-integrator.sage
+++ b/transition-integrator.sage
@@ -87,7 +87,7 @@ def integrate_ode(ode_label):
     tm = ode.numerical_transition_matrix(path, 10^(-precision), assume_analytic=true)
 
     max_err = max( x.diameter() for x in tm.list() )    
-    print "\tODE", label, "is complete. Max error: ", max_err
+    print "\tODE {:8} is complete. Max error: {}".format(label, max_err)
     
     # Check if M has been computed approximately or exactly.
     # We basically always receive exact input.
@@ -141,7 +141,7 @@ if __name__ == '__main__':
     print "Integration completed in",time.time()-t0,"seconds."
     
 ## Function for patching together data from the parallelization.
-print "rearranging the matrices"
+print "Rearranging the matrices. Writing to file..."
 
 def ith_compatible_matrix(i):
     # File contains `change_coordinates`
@@ -149,8 +149,7 @@ def ith_compatible_matrix(i):
     tm =  matrix( field, [tms[k].list() for k in tms.keys() if k[0] == i+1] )
     return change_coordinates*tm
 
-total_transition_mat = prod( ith_compatible_matrix(i) for i in range(steps) )
-
 ## Write to file.
 with open(ivpdir+"transition_mat",'w') as  outfile:
+    total_transition_mat = prod( ith_compatible_matrix(i) for i in range(steps) )
     pickle.dump( ARBMatrixCerealWrap(total_transition_mat), outfile )

--- a/transition-integrator.sage
+++ b/transition-integrator.sage
@@ -1,162 +1,253 @@
 pathToSuite="/usr/people/avinash/Gauss-Manin/PeriodSuite/";
 load(pathToSuite+"ivpdir.sage")
-ncpus=100
+
+
+## Because whoever wrote the boiler plate for the ARB library did it wrong.
+
 
 print("Beginning integration...")
 load(ivpdir+"meta.sage")
 
+### FORMAT OF META.SAGE FILE:
+# steps
+# precision
+# d
+# fermat_type
+# reduce
+
+
 import time
+import pickle
+import multiprocessing as mp
 from ore_algebra import *
+
 DOP, t, D = DifferentialOperators()
 
 bit_precision=ceil(log(10^(precision+10))/log(2))+100
 field=ComplexBallField(bit_precision)
 
-#@parallel(ncpus=ncpus)
-def integrate_ode(ode_label):
-    load(ode_label)
-    if loop_position > -1:
-        return integrate_ode_with_loop(ode_label)
-    tm=ode.numerical_transition_matrix(path, 10^(-precision), assume_analytic=true)
-    print "\tODE", label, "is complete. Max error: ", max(tm.apply_map(lambda x : x.diameter()).list())
-    M=Matrix(init)
-    if not (M.base_ring() == Rationals() or M.base_ring() == Integers()):
-        M=MatrixSpace(ComplexBallField(tm.parent().base().precision()),M.nrows(),M.ncols())(M)
-    TM=tm.row(0)*M
-    return [convert(TM),False,label]
+class ARBMatrixCerealWrap:
+    """
+    A wrapper class to enable serialization of complex arb matrix objects. The original arb matrix
+    can be constructed.
+    """
+    def __init__(self, arb_mat):
+        self.nrows = arb_mat.nrows()
+        self.ncols = arb_mat.ncols()
+        self.arb_entries = [ [x.mid(), x.diameter()] for x in arb_mat.list()]
 
-def integrate_ode_with_loop(ode_label):
-    load(ode_label)
-    path1=path[0:loop_position]
-    path2=path[loop_position-1:-1]
-    ## not super efficient!
-    #path3=[path[loop_position],path[len(path)-1]]
-    #path3=[path[0],path[-1]]
-    path3=path
-    tm1=ode.numerical_transition_matrix(path1, 10^(-precision), assume_analytic=true)
-    #print "\tODE", label, "is completed until loop. Max error: ", max(tm1.apply_map(lambda x : x.diameter()).list())
-    tm2=ode.numerical_transition_matrix(path2, 10^(-precision), assume_analytic=true)
-    #print "\tODE", label, "loop completed. Max error: ", max(tm2.apply_map(lambda x : x.diameter()).list())
-    tm3=ode.numerical_transition_matrix(path3, 10^(-precision), assume_analytic=true)
-    max_err=max([max(tm.apply_map(lambda x : x.diameter()).list()) for tm in [tm1,tm2,tm3]])
-    print "\tODE", label, "loop and limit completed. Max error: ", max_err
-    M=Matrix(init)
-    if not (M.base_ring() == Rationals() or M.base_ring() == Integers()):
-        M=MatrixSpace(ComplexBallField(tm1.parent().base().precision()),M.nrows(),M.ncols())(M)
-    TM1=tm1.row(0)*M
-    TM2=(tm2.row(0)*tm1)*M
-    #TM3=tm3*tm1*M 
-    TM3=tm3*M 
-    return [convert(TM1),convert(TM2),convert(TM3),ode,True,label]
+    def ball_field_elem(self, x):
+        return field(x[0]).add_error(x[1])
     
-def convert(cbf_matrix):
-    return [cbf_matrix.apply_map(lambda x : x.mid()),cbf_matrix.apply_map(lambda x : x.diameter())]
+    def arb_matrix(self):
+        return matrix(field, self.nrows , self.ncols, map(self.ball_field_elem, self.arb_entries)  )
+        
+    def list(self):
+        return self.arb_entries
 
-def convert_to_matrix_with_error(matrix,error):
-    new_matrix=MatrixSpace(field,matrix.nrows(),matrix.ncols())(matrix)
-    for i in [1..matrix.nrows()]:
-        for j in [1..matrix.ncols()]:
-            new_matrix[i-1,j-1]=new_matrix[i-1,j-1].add_error(error[i-1,j-1]) 
-    return new_matrix
+"""
+An ode label is of the form (step_number, equation_number). The (i,j)-th equation is the $j$-th ode
+of the i-th step.
 
-def construct_matrix(keys, dictionary):
-    # given an ordered list of keys, get the corresponding rows in dictionary 
-    # and form the mxn matrix
-    data = [dictionary[key] for key in keys]
-    mat=Matrix([dat[0] for dat in data])
-    err=Matrix([dat[1] for dat in data])
-    return convert_to_matrix_with_error(mat,err)
+The function integrates this equation and determines the functional for how the initial conditions
+change in terms of the original initial conditions.
 
-def compute_periods_of_fermat():
-    print "Computing periods of Fermat"
-    t0=time.time()
-    load(pathToSuite+"fermat_periods.sage")
-    # fermat_type and the degree d of fermat are loaded from the file "meta.sage"
-    fermat_period_matrix=periods_of_fermat(fermat_type)
-    print "Fermat periods computed in", time.time() -t0, "seconds."
-    fpm_rows=fermat_period_matrix.nrows()
-    fpm_cols=fermat_period_matrix.ncols()
-    return MatrixSpace(field,fpm_rows,fpm_cols)(fermat_period_matrix);
+The return type of this function is a tuple [ TMconv, Bool, label]. Here
 
-def output_to_file(periods,filename):
-    output_file = open(ivpdir+filename,'w')
-    maximal_error=max(periods.apply_map(lambda x : x.diameter()).list());
-    periods_mid=periods.apply_map(lambda x : x.mid());
-    print "Accumulated maximal error:", maximal_error
-    if maximal_error == 0:
-        attained_precision=precision
-    else:
-        attained_precision=-maximal_error.log(10).round()
-    output_file.write(str(attained_precision)+"\n")
-    digits=ceil(attained_precision*1.2);
-    output_file.write(str(digits)+"\n")
-    t0=time.time()
-    print "Writing the periods to file."
-    numrows=periods_mid.nrows()
-    numcols=periods_mid.ncols()
-    for i in [1..numrows]:
-        output_file.write(str(periods_mid[i-1].list()))
-        if i < numrows: output_file.write("\n")
-    output_file.close()
+-- Bool is a variable that is always False, indicating the number of loops.
+-- TMconv is the deconstructed form of a complex ball matrix. A tuple [A,B] where A is the matrix
+   of midpoints and B is the matrix of errors.
+
+   NOTE: The only reason for this format is that Sage's @parallel decorator is miserable. In our code
+         I think we should just parallelize by hand.
+
+-- label is the dictionary label for the ode.
+
+Given an ode_label identifying which of the 21
 
 
+====================================================
+EXAMPLE FORMAT OF THE "IVP-*-*.sage" FILE:
+
+ode=D^2 + 3*t/(t^2 - 4)*D + 3/4/(t^2 - 4)
+init=[
+[ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0 ],
+[ 0, 0, 0, 0, 1/4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+]
+path=[ 0, 1 ]
+label=(1,2)
+loop_position=-1
+
+"""
+
+## This decorator is evil...
+#@parallel
+def integrate_ode(ode_label):
+    print("Integration started")    
+
+    # Load the file with the ode_label.
+    load(ode_label)
+    # File defines values:
+    #
+    # ode
+    # init
+    # path
+    # label
+    # loop_position
+
+    # Form matrix of initial conditions.
+    M = Matrix(init)
+
+    
+    # At this point, we should decide on
+    # -- integration path (via voronoi method),
+    
+    tm = ode.numerical_transition_matrix(path, 10^(-precision), assume_analytic=true)
+
+    max_err = max( x.diameter() for x in tm.list() )    
+    print "\tODE", label, "is complete. Max error: ", max_err
+    
+    # Check if M has been computed approximately or exactly.
+    # We basically always receive exact input.
+    if not (M.base_ring() == Rationals() or M.base_ring() == Integers()):
+        M = MatrixSpace(ComplexBallField(tm.parent().base().precision()), M.nrows(), M.ncols())(M)
+
+    # Compute the correct transition row from the ODE and initial conditions.
+    # due to a bug with the Arb-Sage interface, we have to convert to a portable object.
+    TM = matrix(tm.row(0)*M)    
+    TMcomp = ARBMatrixCerealWrap(TM)
+
+    
+    # write the row to a file
+    #with open(ode_label + '-solution','w') as sol_file:
+    #    #sol_file.write( str( ARBMatrixCerealWrap(TM).arb_entries )
+    #    #pickle.dump(TMcomp, sol_file)
+        
+    return [TMcomp,False,label]
+
+
+
+########################################################################################
+
+## Conversion file for pickling complex_ball objects.
+
+## Save
+
+# Takes a complex ball matrix and converts it into a pair of matrices `[A,B]`, with `A` the midpoints
+# of the ball and `B` the errors of the ball.
+# def convert(cbf_matrix):
+#     return [cbf_matrix.apply_map(lambda x : x.mid()), cbf_matrix.apply_map(lambda x : x.diameter())]
+
+
+########################################################################################
+
+## Format output and save.
+#  Takes an unconverted complex ball matrix. Converts it and writes to a file.
+# def output_to_file(compl_ball_mat,filename):
+#     output_file = open(ivpdir+filename,'w')
+#     maximal_error=max(compl_ball_mat.apply_map(lambda x : x.diameter()).list());
+#     compl_ball_mat_mid=compl_ball_mat.apply_map(lambda x : x.mid());
+#     print "Accumulated maximal error:", maximal_error
+#     if maximal_error == 0:
+#         attained_precision=precision
+#     else:
+#         attained_precision=-maximal_error.log(10).round()
+
+#     # Write the precision and digits to the first two lines.
+#     output_file.write(str(attained_precision)+"\n")
+#     digits=ceil(attained_precision*1.2);
+#     output_file.write(str(digits)+"\n")
+
+#     # Write the rest of the matrix.
+#     # Force the matrix to print entry by entry.
+#     t0=time.time()
+#     print "Writing the complex_ball_matrix to file."
+#     numrows = compl_ball_mat_mid.nrows()
+#     numcols = compl_ball_mat_mid.ncols()
+#     for i in [1..numrows]:
+#         output_file.write(str(compl_ball_mat_mid[i-1].list()))
+#         if i < numrows: output_file.write("\n")
+#     output_file.close()
+
+
+###################################################################################################
+    
 
 ## Transition matrices but without intermediate base changes
 tms={}
-## the transition matrices around loops, if any
-loops={}
-## in case of loop, the final transition matrix and odes
-limit_tm={}
-limit_periods={}
-final_odes={}
 
 t0=time.time()
 ivps=[]
 for file in os.listdir(ivpdir):
     if file.startswith("IVP-") and file.endswith(".sage"):
         ivps.append(os.path.join(ivpdir,file))
+        
 ivps.sort()
-## most time consuming part
-for solution in integrate_ode(ivps):
-    has_loop=solution[-1][-2]
-    label=solution[-1][-1]
-    if has_loop:
-        tms[label]=solution[-1][0]
-        loops[label]=solution[-1][1]
-        limit_tm[label]=solution[-1][2]
-        final_odes[label]=solution[-1][3]
-    else:
-        tms[label]=solution[-1][0]
-print "Integration completed in",time.time()-t0,"seconds."
-loop_keys=loops.keys()
-loop_keys.sort()
 
-## Transition matrices made compatible with base changes
-base_change_files=[]
-for file in os.listdir(ivpdir):
-    if file.startswith("BaseChange-") and file.endswith(".sage"):
-        base_change_files.append(os.path.join(ivpdir,file))
-base_change_files.sort()
+#######################
+# Parallelization by hand.
+
+if __name__ == '__main__':
+
+    pool = mp.Pool(mp.cpu_count() - 10) # In case someone is using the cores.
+
+    ## most time consuming part: where the solutions are actually tracked.
+    results = pool.map(integrate_ode, ivps)
+    
+    for solution in results:
+        label      = solution[-1]
+        tms[label] = solution[0]
+
+print "Integration completed in",time.time()-t0,"seconds."
 
 
 t0=time.time()
 keys=tms.keys()
-steps=len(base_change_files)
 compatible_tms=[1..steps]
+
+#####
+## Helper function for "construct matrix with error" Turns a pair of matrices into a complex ball matrix.
+# def convert_to_matrix_with_error(matrix,error):
+#     new_matrix=MatrixSpace(field,matrix.nrows(),matrix.ncols())(matrix)
+#     for i in [1..matrix.nrows()]:
+#         for j in [1..matrix.ncols()]:            
+#             new_matrix[i-1,j-1]=new_matrix[i-1,j-1].add_error(error[i-1,j-1]) 
+#     return new_matrix
+
+# ## Essentially the inverse to "convert", but operating on the entire data structure at the same time.
+# def construct_matrix(keys, dictionary):
+#     # given an ordered list of keys, get the corresponding rows in dictionary 
+#     # and form the mxn matrix
+#     data = [dictionary[key] for key in keys]
+#     mat=Matrix([dat[0] for dat in data])
+#     err=Matrix([dat[1] for dat in data])
+#     return convert_to_matrix_with_error(mat,err)
+
+##### END FUN BLOCK
+
+## Transition matrices made compatible with base changes
+#  The transition matrices are computed from MAGMA.
+basis_change_files=[]
+for file in os.listdir(ivpdir):
+    if file.startswith("BaseChange-") and file.endswith(".sage"):
+        basis_change_files.append(os.path.join(ivpdir,file))
+basis_change_files.sort()
 
 
 ## Function for patching together data from the parallelization.
 print "rearranging the matrices"
 for i in [1..steps]:
-    nrows=max([k[1] for k in keys if k[0] == i])
-    #ncols=len(tms[(i,1)][0])
-    tm_with_error=construct_matrix([(i,j) for j in [1..nrows]],tms)
-    load(base_change_files[i-1])
-    compatible_tms[i-1]=change_coordinates*tm_with_error
+    #nrows = max([k[1] for k in keys if k[0] == i])
+    #tm_with_error = construct_matrix([(i,j) for j in [1..nrows]],tms)
+    tm = matrix( field, [tms[k].list() for k in keys if k[0] == i] )
+    load(basis_change_files[i-1])
+    compatible_tms[i-1]=change_coordinates*tm
 
 
 ## Some formatting of these complex ball matrices required.
 with open(ivpdir+"transition_mat",'w') as  outfile:
-    outfile.write(str(compatible_tms))
-    
+    total_transition_mat = prod(compatible_tms)
+    pickle.dump( ARBMatrixCerealWrap(total_transition_mat), outfile )
 
+
+output_to_file( prod(compatible_tms) , "transition_mat-raw")

--- a/transition-integrator.sage
+++ b/transition-integrator.sage
@@ -133,8 +133,10 @@ basis_change_files.sort()
 ## The most time consuming part: where the solutions are actually tracked.
 if __name__ == '__main__':    
     tms={}    
-    pool = mp.Pool(mp.cpu_count() - 10)
-    results = pool.map(integrate_ode, ivps)
+    #pool = mp.Pool(mp.cpu_count() - 10)
+    #results = pool.map(integrate_ode, ivps)
+
+    results = map(integrate_ode, ivps)
     for solution in results:
         label      = solution[-1]
         tms[label] = solution[0]

--- a/transition-integrator.sage
+++ b/transition-integrator.sage
@@ -53,9 +53,6 @@ The return type of this function is a tuple [ TMconv, Bool, label], where:
 -- TMconv is the deconstructed form of a complex ball matrix. A tuple [A,B] where A is the matrix
    of midpoints and B is the matrix of errors.
 
-   NOTE: The only reason for this format is that Sage's @parallel decorator is miserable. In our code
-         I think we should just parallelize by hand.
-
 -- label is the dictionary label for the ode.
 
 ====================================================

--- a/transition-integrator.sage
+++ b/transition-integrator.sage
@@ -12,7 +12,7 @@ DOP, t, D = DifferentialOperators()
 bit_precision=ceil(log(10^(precision+10))/log(2))+100
 field=ComplexBallField(bit_precision)
 
-@parallel(ncpus=ncpus)
+#@parallel(ncpus=ncpus)
 def integrate_ode(ode_label):
     load(ode_label)
     if loop_position > -1:
@@ -155,8 +155,8 @@ for i in [1..steps]:
     compatible_tms[i-1]=change_coordinates*tm_with_error
 
 
-with open(ivpdir+filename,'w') as  outfile:
-    outfile.write(tm_with_error)
-    outfile.write(compatible_tms)
+## Some formatting of these complex ball matrices required.
+with open(ivpdir+"transition_mat",'w') as  outfile:
+    outfile.write(str(compatible_tms))
     
 

--- a/transition-integrator.sage
+++ b/transition-integrator.sage
@@ -1,12 +1,12 @@
 pathToSuite="/usr/people/avinash/Gauss-Manin/PeriodSuite/";
 load(pathToSuite+"ivpdir.sage")
 
-
-## Because whoever wrote the boiler plate for the ARB library did it wrong.
-
+import time
+import pickle
+import multiprocessing as mp
+from ore_algebra import *
 
 print("Beginning integration...")
-load(ivpdir+"meta.sage")
 
 ### FORMAT OF META.SAGE FILE:
 # steps
@@ -14,22 +14,16 @@ load(ivpdir+"meta.sage")
 # d
 # fermat_type
 # reduce
+load(ivpdir+"meta.sage")
 
-
-import time
-import pickle
-import multiprocessing as mp
-from ore_algebra import *
-
-DOP, t, D = DifferentialOperators()
-
-bit_precision=ceil(log(10^(precision+10))/log(2))+100
-field=ComplexBallField(bit_precision)
+DOP, t, D     = DifferentialOperators()
+bit_precision = ceil(log(10^(precision+10))/log(2))+100
+field         = ComplexBallField(bit_precision)
 
 class ARBMatrixCerealWrap:
     """
     A wrapper class to enable serialization of complex arb matrix objects. The original arb matrix
-    can be constructed.
+    can be constructed via the `arb_matrix` method.
     """
     def __init__(self, arb_mat):
         self.nrows = arb_mat.nrows()
@@ -52,7 +46,7 @@ of the i-th step.
 The function integrates this equation and determines the functional for how the initial conditions
 change in terms of the original initial conditions.
 
-The return type of this function is a tuple [ TMconv, Bool, label]. Here
+The return type of this function is a tuple [ TMconv, Bool, label], where:
 
 -- Bool is a variable that is always False, indicating the number of loops.
 -- TMconv is the deconstructed form of a complex ball matrix. A tuple [A,B] where A is the matrix
@@ -79,29 +73,17 @@ label=(1,2)
 loop_position=-1
 
 """
-
-## This decorator is evil...
-#@parallel
 def integrate_ode(ode_label):
     print("Integration started")    
 
     # Load the file with the ode_label.
     load(ode_label)
-    # File defines values:
-    #
-    # ode
-    # init
-    # path
-    # label
-    # loop_position
+    # File defines values: ode, init, path, label, loop_position
 
-    # Form matrix of initial conditions.
-    M = Matrix(init)
-
+    M = Matrix(init)   # The matrix of initial conditions.
     
-    # At this point, we should decide on
-    # -- integration path (via voronoi method),
-    
+    # TODO: At this point, we should decide on
+    # -- integration path (via voronoi method),   
     tm = ode.numerical_transition_matrix(path, 10^(-precision), assume_analytic=true)
 
     max_err = max( x.diameter() for x in tm.list() )    
@@ -112,70 +94,19 @@ def integrate_ode(ode_label):
     if not (M.base_ring() == Rationals() or M.base_ring() == Integers()):
         M = MatrixSpace(ComplexBallField(tm.parent().base().precision()), M.nrows(), M.ncols())(M)
 
-    # Compute the correct transition row from the ODE and initial conditions.
-    # due to a bug with the Arb-Sage interface, we have to convert to a portable object.
+    # Compute the transition row from the ODE and initial conditions.
+    # due to a bug with the Arb-Sage interface, we convert to a portable object.
     TM = matrix(tm.row(0)*M)    
     TMcomp = ARBMatrixCerealWrap(TM)
 
-    
-    # write the row to a file
-    #with open(ode_label + '-solution','w') as sol_file:
-    #    #sol_file.write( str( ARBMatrixCerealWrap(TM).arb_entries )
-    #    #pickle.dump(TMcomp, sol_file)
-        
-    return [TMcomp,False,label]
-
-
-
-########################################################################################
-
-## Conversion file for pickling complex_ball objects.
-
-## Save
-
-# Takes a complex ball matrix and converts it into a pair of matrices `[A,B]`, with `A` the midpoints
-# of the ball and `B` the errors of the ball.
-# def convert(cbf_matrix):
-#     return [cbf_matrix.apply_map(lambda x : x.mid()), cbf_matrix.apply_map(lambda x : x.diameter())]
-
-
-########################################################################################
-
-## Format output and save.
-#  Takes an unconverted complex ball matrix. Converts it and writes to a file.
-# def output_to_file(compl_ball_mat,filename):
-#     output_file = open(ivpdir+filename,'w')
-#     maximal_error=max(compl_ball_mat.apply_map(lambda x : x.diameter()).list());
-#     compl_ball_mat_mid=compl_ball_mat.apply_map(lambda x : x.mid());
-#     print "Accumulated maximal error:", maximal_error
-#     if maximal_error == 0:
-#         attained_precision=precision
-#     else:
-#         attained_precision=-maximal_error.log(10).round()
-
-#     # Write the precision and digits to the first two lines.
-#     output_file.write(str(attained_precision)+"\n")
-#     digits=ceil(attained_precision*1.2);
-#     output_file.write(str(digits)+"\n")
-
-#     # Write the rest of the matrix.
-#     # Force the matrix to print entry by entry.
-#     t0=time.time()
-#     print "Writing the complex_ball_matrix to file."
-#     numrows = compl_ball_mat_mid.nrows()
-#     numcols = compl_ball_mat_mid.ncols()
-#     for i in [1..numrows]:
-#         output_file.write(str(compl_ball_mat_mid[i-1].list()))
-#         if i < numrows: output_file.write("\n")
-#     output_file.close()
-
-
-###################################################################################################
+    # Alternatively, the rows can be written to files to be dealt with later.
+    return [TMcomp,False,label] 
     
 
-## Transition matrices but without intermediate base changes
-tms={}
+###########################################################################################
+# Main script start.
 
+## Look for load files in the directory.
 t0=time.time()
 ivps=[]
 for file in os.listdir(ivpdir):
@@ -184,70 +115,42 @@ for file in os.listdir(ivpdir):
         
 ivps.sort()
 
-#######################
-# Parallelization by hand.
-
-if __name__ == '__main__':
-
-    pool = mp.Pool(mp.cpu_count() - 10) # In case someone is using the cores.
-
-    ## most time consuming part: where the solutions are actually tracked.
-    results = pool.map(integrate_ode, ivps)
-    
-    for solution in results:
-        label      = solution[-1]
-        tms[label] = solution[0]
-
-print "Integration completed in",time.time()-t0,"seconds."
-
-
-t0=time.time()
-keys=tms.keys()
-compatible_tms=[1..steps]
-
-#####
-## Helper function for "construct matrix with error" Turns a pair of matrices into a complex ball matrix.
-# def convert_to_matrix_with_error(matrix,error):
-#     new_matrix=MatrixSpace(field,matrix.nrows(),matrix.ncols())(matrix)
-#     for i in [1..matrix.nrows()]:
-#         for j in [1..matrix.ncols()]:            
-#             new_matrix[i-1,j-1]=new_matrix[i-1,j-1].add_error(error[i-1,j-1]) 
-#     return new_matrix
-
-# ## Essentially the inverse to "convert", but operating on the entire data structure at the same time.
-# def construct_matrix(keys, dictionary):
-#     # given an ordered list of keys, get the corresponding rows in dictionary 
-#     # and form the mxn matrix
-#     data = [dictionary[key] for key in keys]
-#     mat=Matrix([dat[0] for dat in data])
-#     err=Matrix([dat[1] for dat in data])
-#     return convert_to_matrix_with_error(mat,err)
-
-##### END FUN BLOCK
-
 ## Transition matrices made compatible with base changes
 #  The transition matrices are computed from MAGMA.
 basis_change_files=[]
 for file in os.listdir(ivpdir):
     if file.startswith("BaseChange-") and file.endswith(".sage"):
         basis_change_files.append(os.path.join(ivpdir,file))
+
+# TODO: This goes badly wrong if there are 11 base-change files...
 basis_change_files.sort()
 
 
+if __name__ == '__main__':
+
+    ## Transition matrices but without intermediate base changes
+    tms={}    
+
+    ## most time consuming part: where the solutions are actually tracked.
+    pool = mp.Pool(mp.cpu_count() - 10)
+    results = pool.map(integrate_ode, ivps)
+    for solution in results:
+        label      = solution[-1]
+        tms[label] = solution[0]
+
+    print "Integration completed in",time.time()-t0,"seconds."
+    
 ## Function for patching together data from the parallelization.
 print "rearranging the matrices"
-for i in [1..steps]:
-    #nrows = max([k[1] for k in keys if k[0] == i])
-    #tm_with_error = construct_matrix([(i,j) for j in [1..nrows]],tms)
-    tm = matrix( field, [tms[k].list() for k in keys if k[0] == i] )
-    load(basis_change_files[i-1])
-    compatible_tms[i-1]=change_coordinates*tm
 
+def ith_compatible_matrix(i):
+    # File contains `change_coordinates`
+    load(basis_change_files[i])
+    tm =  matrix( field, [tms[k].list() for k in tms.keys() if k[0] == i+1] )
+    return change_coordinates*tm
 
-## Some formatting of these complex ball matrices required.
+total_transition_mat = prod( ith_compatible_matrix(i) for i in range(steps) )
+
+## Write to file.
 with open(ivpdir+"transition_mat",'w') as  outfile:
-    total_transition_mat = prod(compatible_tms)
     pickle.dump( ARBMatrixCerealWrap(total_transition_mat), outfile )
-
-
-output_to_file( prod(compatible_tms) , "transition_mat-raw")

--- a/transition-integrator.sage
+++ b/transition-integrator.sage
@@ -1,0 +1,162 @@
+pathToSuite="/usr/people/avinash/Gauss-Manin/PeriodSuite/";
+load(pathToSuite+"ivpdir.sage")
+ncpus=100
+
+print("Beginning integration...")
+load(ivpdir+"meta.sage")
+
+import time
+from ore_algebra import *
+DOP, t, D = DifferentialOperators()
+
+bit_precision=ceil(log(10^(precision+10))/log(2))+100
+field=ComplexBallField(bit_precision)
+
+@parallel(ncpus=ncpus)
+def integrate_ode(ode_label):
+    load(ode_label)
+    if loop_position > -1:
+        return integrate_ode_with_loop(ode_label)
+    tm=ode.numerical_transition_matrix(path, 10^(-precision), assume_analytic=true)
+    print "\tODE", label, "is complete. Max error: ", max(tm.apply_map(lambda x : x.diameter()).list())
+    M=Matrix(init)
+    if not (M.base_ring() == Rationals() or M.base_ring() == Integers()):
+        M=MatrixSpace(ComplexBallField(tm.parent().base().precision()),M.nrows(),M.ncols())(M)
+    TM=tm.row(0)*M
+    return [convert(TM),False,label]
+
+def integrate_ode_with_loop(ode_label):
+    load(ode_label)
+    path1=path[0:loop_position]
+    path2=path[loop_position-1:-1]
+    ## not super efficient!
+    #path3=[path[loop_position],path[len(path)-1]]
+    #path3=[path[0],path[-1]]
+    path3=path
+    tm1=ode.numerical_transition_matrix(path1, 10^(-precision), assume_analytic=true)
+    #print "\tODE", label, "is completed until loop. Max error: ", max(tm1.apply_map(lambda x : x.diameter()).list())
+    tm2=ode.numerical_transition_matrix(path2, 10^(-precision), assume_analytic=true)
+    #print "\tODE", label, "loop completed. Max error: ", max(tm2.apply_map(lambda x : x.diameter()).list())
+    tm3=ode.numerical_transition_matrix(path3, 10^(-precision), assume_analytic=true)
+    max_err=max([max(tm.apply_map(lambda x : x.diameter()).list()) for tm in [tm1,tm2,tm3]])
+    print "\tODE", label, "loop and limit completed. Max error: ", max_err
+    M=Matrix(init)
+    if not (M.base_ring() == Rationals() or M.base_ring() == Integers()):
+        M=MatrixSpace(ComplexBallField(tm1.parent().base().precision()),M.nrows(),M.ncols())(M)
+    TM1=tm1.row(0)*M
+    TM2=(tm2.row(0)*tm1)*M
+    #TM3=tm3*tm1*M 
+    TM3=tm3*M 
+    return [convert(TM1),convert(TM2),convert(TM3),ode,True,label]
+    
+def convert(cbf_matrix):
+    return [cbf_matrix.apply_map(lambda x : x.mid()),cbf_matrix.apply_map(lambda x : x.diameter())]
+
+def convert_to_matrix_with_error(matrix,error):
+    new_matrix=MatrixSpace(field,matrix.nrows(),matrix.ncols())(matrix)
+    for i in [1..matrix.nrows()]:
+        for j in [1..matrix.ncols()]:
+            new_matrix[i-1,j-1]=new_matrix[i-1,j-1].add_error(error[i-1,j-1]) 
+    return new_matrix
+
+def construct_matrix(keys, dictionary):
+    # given an ordered list of keys, get the corresponding rows in dictionary 
+    # and form the mxn matrix
+    data = [dictionary[key] for key in keys]
+    mat=Matrix([dat[0] for dat in data])
+    err=Matrix([dat[1] for dat in data])
+    return convert_to_matrix_with_error(mat,err)
+
+def compute_periods_of_fermat():
+    print "Computing periods of Fermat"
+    t0=time.time()
+    load(pathToSuite+"fermat_periods.sage")
+    # fermat_type and the degree d of fermat are loaded from the file "meta.sage"
+    fermat_period_matrix=periods_of_fermat(fermat_type)
+    print "Fermat periods computed in", time.time() -t0, "seconds."
+    fpm_rows=fermat_period_matrix.nrows()
+    fpm_cols=fermat_period_matrix.ncols()
+    return MatrixSpace(field,fpm_rows,fpm_cols)(fermat_period_matrix);
+
+def output_to_file(periods,filename):
+    output_file = open(ivpdir+filename,'w')
+    maximal_error=max(periods.apply_map(lambda x : x.diameter()).list());
+    periods_mid=periods.apply_map(lambda x : x.mid());
+    print "Accumulated maximal error:", maximal_error
+    if maximal_error == 0:
+        attained_precision=precision
+    else:
+        attained_precision=-maximal_error.log(10).round()
+    output_file.write(str(attained_precision)+"\n")
+    digits=ceil(attained_precision*1.2);
+    output_file.write(str(digits)+"\n")
+    t0=time.time()
+    print "Writing the periods to file."
+    numrows=periods_mid.nrows()
+    numcols=periods_mid.ncols()
+    for i in [1..numrows]:
+        output_file.write(str(periods_mid[i-1].list()))
+        if i < numrows: output_file.write("\n")
+    output_file.close()
+
+
+
+## Transition matrices but without intermediate base changes
+tms={}
+## the transition matrices around loops, if any
+loops={}
+## in case of loop, the final transition matrix and odes
+limit_tm={}
+limit_periods={}
+final_odes={}
+
+t0=time.time()
+ivps=[]
+for file in os.listdir(ivpdir):
+    if file.startswith("IVP-") and file.endswith(".sage"):
+        ivps.append(os.path.join(ivpdir,file))
+ivps.sort()
+## most time consuming part
+for solution in integrate_ode(ivps):
+    has_loop=solution[-1][-2]
+    label=solution[-1][-1]
+    if has_loop:
+        tms[label]=solution[-1][0]
+        loops[label]=solution[-1][1]
+        limit_tm[label]=solution[-1][2]
+        final_odes[label]=solution[-1][3]
+    else:
+        tms[label]=solution[-1][0]
+print "Integration completed in",time.time()-t0,"seconds."
+loop_keys=loops.keys()
+loop_keys.sort()
+
+## Transition matrices made compatible with base changes
+base_change_files=[]
+for file in os.listdir(ivpdir):
+    if file.startswith("BaseChange-") and file.endswith(".sage"):
+        base_change_files.append(os.path.join(ivpdir,file))
+base_change_files.sort()
+
+
+t0=time.time()
+keys=tms.keys()
+steps=len(base_change_files)
+compatible_tms=[1..steps]
+
+
+## Function for patching together data from the parallelization.
+print "rearranging the matrices"
+for i in [1..steps]:
+    nrows=max([k[1] for k in keys if k[0] == i])
+    #ncols=len(tms[(i,1)][0])
+    tm_with_error=construct_matrix([(i,j) for j in [1..nrows]],tms)
+    load(base_change_files[i-1])
+    compatible_tms[i-1]=change_coordinates*tm_with_error
+
+
+with open(ivpdir+filename,'w') as  outfile:
+    outfile.write(tm_with_error)
+    outfile.write(compatible_tms)
+    
+

--- a/transition-integrator.sage
+++ b/transition-integrator.sage
@@ -1,5 +1,10 @@
 pathToSuite="/usr/people/avinash/Gauss-Manin/PeriodSuite/";
-load(pathToSuite+"ivpdir.sage")
+
+# Magma source has been changed so that the Temp-directory is sent via the System call.
+# This enables us to specify the load directory from a sage application, as well as prevent
+# a concurrency issue.
+""" Example statement: ivpdir="/usr/people/avinash/Gauss-Manin/PeriodSuite/ode_storage/test/" """
+
 load("voronoi_path.sage")
 
 import time

--- a/voroni_path.sage
+++ b/voroni_path.sage
@@ -1,0 +1,51 @@
+
+
+from sage.geometry.voronoi_diagram import VoronoiDiagram
+
+######
+# Takes a list of polynomials, and constructs a rectangular path from 0 to 1 avoiding
+# the (non 0 or 1) roots of the polynomials
+def voronoi_path(polylist):
+    pts=set()
+    P.<s>=PolynomialRing(QQ)
+    print "Solving for dangerous points..."
+    for p in polylist:
+        p=P(p).radical()
+        # numerical instability messes up the roots at 0 and 1, we will add them manually
+        if p(0) == 0:
+            p=P(p/s)
+        if p(1) == 0:
+            p=P(p/(s-1))
+        roots=[r[0] for r in p.roots(ring=ComplexField(300))]
+        pts = pts.union(set((real(r).simplest_rational(),imag(r).simplest_rational()) for r in roots))
+    
+    R=QQ
+    pts.add((R(0),R(0)))
+    pts.add((R(1),R(0)))
+    if len(pts) == 2:
+        return [0,1]
+    # to discourage paths going in off directions
+    [[pts.add((R(i),R(j))) for i in {-1,1}] for j in {-1,1}]
+
+    print "Constructing Voronoi diagram..."
+    vd = VoronoiDiagram(pts)
+
+    print "Finding shortest path..."
+    gr=Graph()
+    for pt_, reg in vd.regions().iteritems():
+        pt = tuple(pt_)
+        pt = pt[0] + I*pt[1]
+        ptc = CDF(pt)
+        for edge in reg.bounded_edges():
+            u = edge[0][0]+I*edge[0][1]
+            v = edge[1][0]+I*edge[1][1]
+            uc, vc = CDF(u), CDF(v)
+            ratio = (uc-vc).abs()/min((ptc-uc).abs(), (ptc-vc).abs(), (ptc-(uc+vc)/2).abs())
+            gr.add_edge(u, v, label=float(ratio))
+
+        if pt == 0 or pt == 1:
+            for v in reg.vertices():
+                u = v[0]+I*v[1]
+                gr.add_edge(pt, u, 1.0)
+    
+    return gr.shortest_path(QQ(0), QQ(1), by_weight=True), pts

--- a/voronoi_path.sage
+++ b/voronoi_path.sage
@@ -1,13 +1,21 @@
 
-
 from sage.geometry.voronoi_diagram import VoronoiDiagram
+
+def simplest_gaussian_rational(r):
+    return (real(r).simplest_rational(), imag(r).simplest_rational())
 
 ######
 # Takes a list of polynomials, and constructs a rectangular path from 0 to 1 avoiding
 # the (non 0 or 1) roots of the polynomials
+#
+# Returns the best expected path, as well as the list of singular points.
 def voronoi_path(polylist):
-    pts=set()
-    P.<s>=PolynomialRing(QQ)
+
+    R   = QQ
+    pts = set()
+    P   = polylist[0].parent()    
+    s   = gens(P)[0]
+    
     print "Solving for dangerous points..."
     for p in polylist:
         p=P(p).radical()
@@ -17,14 +25,14 @@ def voronoi_path(polylist):
         if p(1) == 0:
             p=P(p/(s-1))
         roots=[r[0] for r in p.roots(ring=ComplexField(300))]
-        pts = pts.union(set((real(r).simplest_rational(),imag(r).simplest_rational()) for r in roots))
+        pts = pts.union(set(simplest_gaussian_rational(r) for r in roots))
     
-    R=QQ
     pts.add((R(0),R(0)))
     pts.add((R(1),R(0)))
     if len(pts) == 2:
         return [0,1]
-    # to discourage paths going in off directions
+
+    # Add a bounding box to discourage paths going in off directions
     [[pts.add((R(i),R(j))) for i in {-1,1}] for j in {-1,1}]
 
     print "Constructing Voronoi diagram..."
@@ -49,3 +57,7 @@ def voronoi_path(polylist):
                 gr.add_edge(pt, u, 1.0)
     
     return gr.shortest_path(QQ(0), QQ(1), by_weight=True), pts
+
+
+##########################3
+


### PR DESCRIPTION
Various changes:
-- added "TransitionHomotopy" methods to suite.mag
-- Renamed PeriodSuiteTempDir to IVPWorkingDir
-- After constructing IVPs, magma also writes a ".PeriodSuite-dir-is-safe-to-overwrite". This guards against the user accidentally running a "rm -fr" system call on the wrong directory. This can be really bad as when PeriodHomotopy is called with "name:=../../../someotherplace" and "overwrite:=true", the "rm -fr" call can bring ruin.

--  Comment headers inside "suite.mag" to delineate code.
-- CheckIfIVPDirectoryExists function created, to eliminate code duplication.
-- transition-integrator.sage file added. The code can now compute transition matrices for homotopies. The output is pickled and saved as a sage object.
-- Removed the read/write to ivpdir.sage file. The directory information is now passed directly to sage in the System call.