### PR TITLE
Changed arb matrix load to import.

### DIFF
--- a/arb_matrix_cereal_wrap.py
+++ b/arb_matrix_cereal_wrap.py
@@ -1,0 +1,27 @@
+
+from sage.all import *
+
+class ARBMatrixCerealWrap:
+    """
+    A wrapper class to enable serialization of complex arb matrix objects. The original arb matrix
+    can be constructed via the `arb_matrix` method.
+    """
+    def __init__(self, arb_mat):
+        self.nrows = arb_mat.nrows()
+        self.ncols = arb_mat.ncols()
+        self.arb_entries = [ [x.mid(), x.diameter()] for x in arb_mat.list()]
+        self.base_ring = arb_mat.base_ring()
+
+    def ball_field_elem(self, x):
+        return self.base_ring(x[0]).add_error(x[1])
+    
+    def arb_matrix(self):
+        return matrix(self.base_ring, self.nrows , self.ncols,
+                      map(self.ball_field_elem, self.arb_entries))
+        
+    def list(self):
+        return self.arb_entries
+
+    def entries_as_arbs(self):
+        raw_out_data = self.arb_entries
+        return [self.base_ring(x[0]).add_error(x[1]) for x in raw_out_data]

--- a/transition-integrator.sage
+++ b/transition-integrator.sage
@@ -54,7 +54,9 @@ except NameError:
 # Begin main script.
 
 load(pathToSuite + "voronoi_path.sage")
-load(pathToSuite + "arb_matrix_cereal_wrap.sage")
+#load(pathToSuite + "arb_matrix_cereal_wrap.sage")
+
+import arb_matrix_cereal_wrap as amcw
 
 import time
 import pickle
@@ -160,7 +162,7 @@ def integrate_ode(ode_label, path):
     print("    ODE {:<8} is complete. Max error: {}".format(str(label), max_err))
     
     # due to a bug with the Arb-Sage interface, convert to a portable object.
-    transition_row = ARBMatrixCerealWrap(matrix(transition_mat.row(0)*initial_conditions))
+    transition_row = amcw.ARBMatrixCerealWrap(matrix(transition_mat.row(0)*initial_conditions))
         
     return [transition_row,False,label] 
 #####
@@ -235,6 +237,6 @@ def ith_compatible_matrix(i):
 print("Rearranging the matrices. Writing to file...")
 
 total_transition_mat = prod(ith_compatible_matrix(i) for i in range(steps))
-save(ARBMatrixCerealWrap(total_transition_mat), ivpdir+"transition_mat.sobj")
+save(amcw.ARBMatrixCerealWrap(total_transition_mat), ivpdir+"transition_mat.sobj")
 
 exit()


### PR DESCRIPTION
Changes loading of the arb_matrix class so that the class definition appears in a submodule, as opposed to __main__. This makes it so that the class can be imported into other modules.